### PR TITLE
ci: use trusted publisher deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
     name: Distribution build
     runs-on: ubuntu-latest
     needs: [pre-commit]
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -78,9 +81,4 @@ jobs:
         with:
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.6
-        if: github.event_name == 'release' && github.event.action == 'published'
-        with:
-          user: __token__
-          # Remember to generate this and set it in "GitHub Secrets"
-          password: ${{ secrets.pypi_password }}
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Following the Scikit-HEP Developer Guidelines. The secret should be deleted on GHA, the token deleted on PyPI, and this repo and pypi environment be set on PyPI's project page as a trusted publisher.
