### PR TITLE
feat: Allow for generating madgraph proc card from TOML config

### DIFF
--- a/templates/defaults.toml
+++ b/templates/defaults.toml
@@ -46,6 +46,7 @@ ptj1min = 0
 [madgraph.proc]
 name = "VBFSUSY_EWKQCD"
 card = "{{madgraph['proc']['name']}}"
+contents = false
 
 [madspin]
 skip = true


### PR DESCRIPTION
Resolves #70. Adds `madgraph.proc.contents` which is defaulting to `false` in the base template.
