### PR TITLE
feat: mg5config to mg5commands, and add new madgraph.commands subsection

### DIFF
--- a/src/mapyde/backends/madgraph.py
+++ b/src/mapyde/backends/madgraph.py
@@ -324,30 +324,17 @@ def generate_mg5config(config: ImmutableConfig) -> None:
         madspin_onoff = "ON"
         madspin_config_path = f"/data/{new_madspin_card_path.name}"
 
-    mg5config = f"""
-{run_mode}
-launch PROC_madgraph
-madspin={madspin_onoff}
-shower={pythia_onoff}
-reweight=OFF
-{madspin_config_path}
-/data/{new_param_card_path.name}
-/data/{new_run_card_path.name}
-{pythia_config_path}
-set iseed {config['madgraph']['run']['seed']}
-done
-"""
+    mg5config = config["madgraph"]["config"]
     if is_old_version:
-        mg5config = f"""
-{run_mode}
-launch PROC_madgraph
-madspin={madspin_onoff}
-reweight=OFF
-{madspin_config_path}
-/data/{new_param_card_path.name}
-/data/{new_run_card_path.name}
-done
-"""
+        mg5config = "\n".join(
+            line
+            for line in mg5config.splitlines()
+            if not line.startswith("set iseed")
+            and not line.startswith("shower=")
+            and not line.startswith("{pythia_config_path}")
+        )
+
+    mg5config_parsed = mg5config.format(**locals())
 
     with mgconfig_card_path.open(mode="w", encoding="utf-8") as fpointer:
         # pylint: disable-next=consider-using-with
@@ -359,4 +346,4 @@ done
                     fpointer.write("output PROC_madgraph\n")
                 else:
                     fpointer.write(proc_line)
-        fpointer.write(mg5config)
+        fpointer.write(mg5config_parsed)

--- a/src/mapyde/backends/madgraph.py
+++ b/src/mapyde/backends/madgraph.py
@@ -78,7 +78,7 @@ def generate_proc_card(config: ImmutableConfig, output_path: Path) -> Path:
     return new_proc_card_path
 
 
-def generate_mg5config(config: ImmutableConfig) -> None:
+def generate_mg5commands(config: ImmutableConfig) -> None:
     """
     Helper for generating the madgraph configs. Replaces mg5creator.py.
     """
@@ -282,8 +282,10 @@ def generate_mg5config(config: ImmutableConfig) -> None:
     new_proc_card_path = generate_proc_card(config, output_path)
 
     # Create the madgraph configuration card
-    mgconfig_card_path = output_path.joinpath(config["madgraph"]["output"])
-    log.info("MadGraph Config: %s", mgconfig_card_path)
+    mgcommands_card_path = output_path.joinpath(
+        config["madgraph"]["commands"]["output"]
+    )
+    log.info("MadGraph Config: %s", mgcommands_card_path)
 
     # Figure out the run_mode.  0=single core, 1=cluster, 2=multicore.
     if config["madgraph"]["batch"]:
@@ -324,19 +326,19 @@ def generate_mg5config(config: ImmutableConfig) -> None:
         madspin_onoff = "ON"
         madspin_config_path = f"/data/{new_madspin_card_path.name}"
 
-    mg5config = config["madgraph"]["config"]
+    mg5commands = config["madgraph"]["config"]
     if is_old_version:
-        mg5config = "\n".join(
+        mg5commands = "\n".join(
             line
-            for line in mg5config.splitlines()
+            for line in mg5commands.splitlines()
             if not line.startswith("set iseed")
             and not line.startswith("shower=")
             and not line.startswith("{pythia_config_path}")
         )
 
-    mg5config_parsed = mg5config.format(**locals())
+    mg5commands_parsed = mg5commands.format(**locals())
 
-    with mgconfig_card_path.open(mode="w", encoding="utf-8") as fpointer:
+    with mgcommands_card_path.open(mode="w", encoding="utf-8") as fpointer:
         # pylint: disable-next=consider-using-with
         with new_proc_card_path.open(encoding="utf-8") as proc_lines:
             for proc_line in proc_lines:
@@ -346,4 +348,4 @@ def generate_mg5config(config: ImmutableConfig) -> None:
                     fpointer.write("output PROC_madgraph\n")
                 else:
                     fpointer.write(proc_line)
-        fpointer.write(mg5config_parsed)
+        fpointer.write(mg5commands_parsed)

--- a/src/mapyde/backends/madgraph.py
+++ b/src/mapyde/backends/madgraph.py
@@ -102,7 +102,9 @@ def generate_mg5commands(config: ImmutableConfig) -> None:
         sys.exit(1)
 
     # Controls whether to run Pythia8 or not
+    # pylint: disable-next=possibly-unused-variable
     pythia_config_path = ""
+    # pylint: disable-next=possibly-unused-variable
     pythia_onoff = "OFF"
     if not config["pythia"]["skip"]:
         # Copy the pythia card
@@ -287,6 +289,8 @@ def generate_mg5commands(config: ImmutableConfig) -> None:
     )
     log.info("MadGraph Config: %s", mgcommands_card_path)
 
+    # pylint: disable-next=possibly-unused-variable
+    run_mode = ""
     # Figure out the run_mode.  0=single core, 1=cluster, 2=multicore.
     if config["madgraph"]["batch"]:
         run_mode = "set run_mode 0"  # we don't have MadGraph launch cluster jobs for us, we handle that ourselves.
@@ -296,7 +300,9 @@ def generate_mg5commands(config: ImmutableConfig) -> None:
         run_mode = f"set run_mode 2\nset nb_core {multiprocessing.cpu_count() / 2}"
 
     # figure out if running with madspin or not, and if so, put the card in the right place
+    # pylint: disable-next=possibly-unused-variable
     madspin_onoff = "OFF"
+    # pylint: disable-next=possibly-unused-variable
     madspin_config_path = ""
     if not config["madspin"]["skip"]:
         # Copy the madspin card

--- a/src/mapyde/backends/madgraph.py
+++ b/src/mapyde/backends/madgraph.py
@@ -339,12 +339,12 @@ def generate_mg5commands(config: ImmutableConfig) -> None:
 
     mg5commands_parsed = render_string(
         mg5commands,
-        dict(
+        {
+            "run_mode": run_mode,
+            "pythia_config_path": pythia_config_path,
+            "madspin_config_path": madspin_config_path,
             **config,
-            run_mode=run_mode,
-            pythia_config_path=pythia_config_path,
-            madspin_config_path=madspin_config_path,
-        ),
+        },
     )
 
     with mgcommands_card_path.open(mode="w", encoding="utf-8") as fpointer:

--- a/src/mapyde/backends/madgraph.py
+++ b/src/mapyde/backends/madgraph.py
@@ -332,7 +332,7 @@ def generate_mg5commands(config: ImmutableConfig) -> None:
         madspin_onoff = "ON"
         madspin_config_path = f"/data/{new_madspin_card_path.name}"
 
-    mg5commands = config["madgraph"]["config"]
+    mg5commands = config["madgraph"]["commands"]["contents"]
     if is_old_version:
         mg5commands = "\n".join(
             line

--- a/src/mapyde/cli/config.py
+++ b/src/mapyde/cli/config.py
@@ -33,4 +33,4 @@ def generate_mg5(filename: str) -> None:
     user = load_config(filename)
     config = build_config(user)
 
-    madgraph.generate_mg5config(config)
+    madgraph.generate_mg5commands(config)

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -71,7 +71,7 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
         config["base"]["output"] = config["base"]["output"] + "_nodecays"
         config["pythia"]["skip"] = True
 
-        madgraph.generate_mg5config(config)
+        madgraph.generate_mg5commands(config)
 
         image = f"ghcr.io/scipp-atlas/mapyde/{config['madgraph']['version']}"
         command = bytes(
@@ -95,7 +95,7 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
         config["base"]["output"] = origout
         config["pythia"]["skip"] = origpythia
 
-    madgraph.generate_mg5config(config)
+    madgraph.generate_mg5commands(config)
 
     image = f"ghcr.io/scipp-atlas/mapyde/{config['madgraph']['version']}"
 

--- a/templates/defaults.toml
+++ b/templates/defaults.toml
@@ -26,8 +26,8 @@ paramcard = "{{madgraph['params']}}.slha"
 [madgraph.commands]
 contents = """{run_mode}
 launch PROC_madgraph
-madspin={madspin_onoff}
-shower={pythia_onoff}
+madspin={{'OFF' if madspin['skip'] else 'ON'}}
+shower={{'OFF' if pythia['skip'] else 'Pythia8'}}
 reweight=OFF
 {madspin_config_path}
 /data/{new_param_card_path.name}

--- a/templates/defaults.toml
+++ b/templates/defaults.toml
@@ -22,8 +22,9 @@ cores = 20
 version = "madgraph"
 batch = false
 paramcard = "{{madgraph['params']}}.slha"
-output = "run.mg5"
-config = """{run_mode}
+
+[madgraph.commands]
+contents = """{run_mode}
 launch PROC_madgraph
 madspin={madspin_onoff}
 shower={pythia_onoff}
@@ -34,6 +35,7 @@ reweight=OFF
 {pythia_config_path}
 set iseed {config['madgraph']['run']['seed']}
 done"""
+output = "run.mg5"
 
 [madgraph.masses]
 MN1 = 100

--- a/templates/defaults.toml
+++ b/templates/defaults.toml
@@ -33,7 +33,7 @@ reweight=OFF
 /data/{new_param_card_path.name}
 /data/{new_run_card_path.name}
 {pythia_config_path}
-set iseed {config['madgraph']['run']['seed']}
+set iseed {madgraph['run']['seed']}
 done"""
 output = "run.mg5"
 

--- a/templates/defaults.toml
+++ b/templates/defaults.toml
@@ -23,6 +23,17 @@ version = "madgraph"
 batch = false
 paramcard = "{{madgraph['params']}}.slha"
 output = "run.mg5"
+config = """{run_mode}
+launch PROC_madgraph
+madspin={madspin_onoff}
+shower={pythia_onoff}
+reweight=OFF
+{madspin_config_path}
+/data/{new_param_card_path.name}
+/data/{new_run_card_path.name}
+{pythia_config_path}
+set iseed {config['madgraph']['run']['seed']}
+done"""
 
 [madgraph.masses]
 MN1 = 100

--- a/templates/ewkinos.toml
+++ b/templates/ewkinos.toml
@@ -21,7 +21,6 @@ version = "madgraph:2.7.3"
 batch = false
 paramcard = "{{madgraph['params']}}.slha"
 run_without_decays = false
-output = "run.mg5"
 
 [madgraph.masses]
 MN2 = 250

--- a/templates/sleptons.toml
+++ b/templates/sleptons.toml
@@ -32,7 +32,7 @@ reweight=OFF
 /data/{new_param_card_path.name}
 /data/{new_run_card_path.name}
 {pythia_config_path}
-set iseed {config['madgraph']['run']['seed']}
+set iseed {madgraph['run']['seed']}
 done"""
 output = "run.mg5"
 

--- a/templates/sleptons.toml
+++ b/templates/sleptons.toml
@@ -25,8 +25,8 @@ paramcard = "{{madgraph['params']}}.slha"
 [madgraph.commands]
 contents = """{run_mode}
 launch PROC_madgraph
-madspin={madspin_onoff}
-shower={pythia_onoff}
+madspin={{'OFF' if madspin['skip'] else 'ON'}}
+shower={{'OFF' if pythia['skip'] else 'Pythia8'}}
 reweight=OFF
 {madspin_config_path}
 /data/{new_param_card_path.name}

--- a/templates/sleptons.toml
+++ b/templates/sleptons.toml
@@ -21,6 +21,19 @@ cores = 1
 version = "madgraph:2.9.3"
 batch = false
 paramcard = "{{madgraph['params']}}.slha"
+
+[madgraph.commands]
+contents = """{run_mode}
+launch PROC_madgraph
+madspin={madspin_onoff}
+shower={pythia_onoff}
+reweight=OFF
+{madspin_config_path}
+/data/{new_param_card_path.name}
+/data/{new_run_card_path.name}
+{pythia_config_path}
+set iseed {config['madgraph']['run']['seed']}
+done"""
 output = "run.mg5"
 
 [madgraph.masses]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,7 +111,7 @@ def test_madgraph_copy_proc_card(tmp_path):
     }
 
     config = mapyde.utils.build_config(user_config)
-    madgraph.generate_mg5config(config)
+    madgraph.generate_mg5commands(config)
 
     output = tmp_path / user_config["base"]["output"]
     assert (output / "charginos").exists()
@@ -137,7 +137,7 @@ def test_madgraph_generate_proc_card(tmp_path):
     }
 
     config = mapyde.utils.build_config(user_config)
-    madgraph.generate_mg5config(config)
+    madgraph.generate_mg5commands(config)
 
     output = tmp_path / user_config["base"]["output"]
     assert (output / "charginos").exists()
@@ -162,4 +162,4 @@ def test_madgraph_proc_card_error(tmp_path):
 
     config = mapyde.utils.build_config(user_config)
     with pytest.raises(AssertionError):
-        madgraph.generate_mg5config(config)
+        madgraph.generate_mg5commands(config)


### PR DESCRIPTION
This allows for a slightly less hard-coded mg5config. We switched from `generate_mg5config` to `generate_mg5commands` which is a bit clearer.